### PR TITLE
Changes to use bitwise operations to improve performance of pc2l

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 build/
 CMakeLists.txt.user
 CMakeCache.txt

--- a/bench/bench_vector.cpp
+++ b/bench/bench_vector.cpp
@@ -57,10 +57,11 @@ BENCHMARK(BM_insert_at_beginning)->Args({0});
 
 int main(int argc, char** argv) {
     auto& pc2l = pc2l::System::get();
-    // set block size to 5 ints
-    pc2l.setBlockSize(sizeof(int) * 5);
+    // Override the default block size to 8 ints
+    const int BlockSize = sizeof(int) * 8;
+    pc2l.setBlockSize(BlockSize);
     // set cache size to 3 blocks
-    pc2l.setCacheSize(3*5*sizeof(int));
+    pc2l.setCacheSize(3 * BlockSize);
     pc2l.initialize(argc, argv);
     pc2l.start();
 

--- a/include/Message.h
+++ b/include/Message.h
@@ -145,7 +145,7 @@ public:
      *
      * \return The a 64-bit key associated with this message.
      */
-    static size_t getKey(size_t dsTag, size_t blockTag) noexcept;
+    static size_t getKey(unsigned int dsTag, unsigned int blockTag) noexcept;
 
     /**
      * Convenience helper method to get an aggregate key for a given

--- a/src/Message.cpp
+++ b/src/Message.cpp
@@ -48,12 +48,19 @@ size_t Message::getKey(const MessagePtr& msg) noexcept {
     return getKey(msg->dsTag, msg->blockTag);
 }
 
-size_t Message::getKey(size_t dsTag, size_t blockTag) noexcept {
+size_t Message::getKey(unsigned int dsTag, unsigned int blockTag) noexcept {
+    // This method assumes that the dsTag and blockTag are exactly 32-bits
+    // in size to pack them into a 64-bit data type.
+    ASSERT(sizeof(dsTag)    == 4);
+    ASSERT(sizeof(blockTag) == 4);
+    ASSERT(sizeof(size_t)   >= 8);
+    
     size_t key = dsTag;
-    key <<= sizeof(dsTag);
+    key <<= 32;  // Shift left by 32-bits
     key |= blockTag;
     return key;
 }
+
 // Create a message from scratch using dynamic memory
 MessagePtr
 Message::create(const int dataSize, const MsgTag tag,


### PR DESCRIPTION
There are two sets of changes in this commit:
 
  1. Corrected the operation for generating keys in message

  2. Testing for using bit-wise operations to keep the code path of vector fast.
     On Pitzer, the changes enable pcl2::vector to be almost the same
     std::vector