### PR TITLE
fix: run tests without crashing, make tests actually run in CI

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -22,7 +22,7 @@ jobs:
       run: cd ${{github.workspace}} && find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format --style=LLVM -i --dry-run -Werror
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build  -DPC2L_ENABLE_TESTS=true -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_BUILD_TYPE=Debug
+      run: cmake -B ${{github.workspace}}/build  -DPC2L_ENABLE_TESTS=true -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_BUILD_TYPE=Release
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: sudo apt-get -y install libopenmpi-dev libgtest-dev libbenchmark-dev && pip install clang-format
+    # - name: Install dependencies
+    #   run: sudo apt-get -y install libopenmpi-dev libgtest-dev libbenchmark-dev && pip install clang-format
 
     - name: Check formatting
       # Check that all of the source code is properly formatted with clang-format

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -6,15 +6,8 @@ on:
   pull_request:
     branches: [ "master" ]
 
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  build-and-test:
     runs-on: ubuntu-24.04
 
     steps:
@@ -29,15 +22,13 @@ jobs:
       run: cd ${{github.workspace}} && find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format --style=LLVM -i --dry-run -Werror
 
     - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build 
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build 
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}} --verbose
+      run: ctest --verbose
 

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -22,7 +22,7 @@ jobs:
       run: cd ${{github.workspace}} && find . -iname '*.h' -o -iname '*.cpp' | xargs clang-format --style=LLVM -i --dry-run -Werror
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build 
+      run: cmake -B ${{github.workspace}}/build  -DPC2L_ENABLE_TESTS=true -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_BUILD_TYPE=Debug
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -39,7 +39,5 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{env.BUILD_TYPE}} --verbose
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_FLAGS_DEBUG 
+set(CMAKE_CXX_FLAGS_DEBUG
 	"${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer")
 
 # Options
@@ -35,27 +35,28 @@ add_subdirectory(src)
 # Only build examples or tests when explicitly requested
 if(PC2L_ENABLE_TESTS)
 	if (PC2L_DOWNLOAD_EXTERNALS)
-	    include(FetchContent)
-	    FetchContent_Declare(
-		    googletest
-		    URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
-	    )
-	    include(GoogleTest)
-	    set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Suppressing benchmark's tests" FORCE)
-	    FetchContent_Declare(googlebenchmark
-		    GIT_REPOSITORY https://github.com/google/benchmark.git
-		    GIT_TAG master) # need master for benchmark::benchmark
-	    FetchContent_MakeAvailable(googletest googlebenchmark)
+		include(FetchContent)
+		FetchContent_Declare(
+						googletest
+						URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+					)
+		include(GoogleTest)
+		set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Suppressing benchmark's tests" FORCE)
+		FetchContent_Declare(googlebenchmark
+						GIT_REPOSITORY https://github.com/google/benchmark.git
+						GIT_TAG master) # need master for benchmark::benchmark
+		FetchContent_MakeAvailable(googletest googlebenchmark)
 	else()
-	    # We need MPI, GoogleTest, GoogleBenchmark for this project to work
-	    find_package(GTest REQUIRED)
-	    find_package(benchmark REQUIRED)
+		# We need MPI, GoogleTest, GoogleBenchmark for this project to work
+		find_package(GTest REQUIRED)
+		find_package(benchmark REQUIRED)
 	endif()
+	enable_testing()
 	add_subdirectory(test)
 	add_subdirectory(bench)
 endif()
 
- if (PC2L_BUILD_EXAMPLES)
- 	add_subdirectory(examples)
- endif()
+if (PC2L_BUILD_EXAMPLES)
+	add_subdirectory(examples)
+endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,35 +16,41 @@ target_link_libraries(big_matrix PRIVATE pc2l_lib)
 target_link_libraries(big_matrix ${MPI_CXX_LIBRARY})
 
 
-add_executable(std_matrix std_matrix.cpp STDMatrix.cpp)
-
-target_compile_features(std_matrix PRIVATE cxx_std_11)
-
-target_link_libraries(std_matrix PRIVATE pc2l_lib)
-
-target_link_libraries(std_matrix ${MPI_CXX_LIBRARY})
-
+# add_executable(std_matrix std_matrix.cpp STDMatrix.cpp)
+#
+# target_compile_features(std_matrix PRIVATE cxx_std_11)
+#
+# target_link_libraries(std_matrix PRIVATE pc2l_lib)
+#
+# target_link_libraries(std_matrix ${MPI_CXX_LIBRARY})
+#
  #Web Cache example
+#
+# add_executable(web_cache web_cache.cpp Matrix.cpp ChildProcess.cpp HTTPFile.cpp)
+#
+# target_compile_features(web_cache PRIVATE cxx_std_11)
+#
+# target_link_libraries(web_cache pc2l_lib)
 
-add_executable(web_cache web_cache.cpp Matrix.cpp ChildProcess.cpp HTTPFile.cpp)
-
-target_compile_features(web_cache PRIVATE cxx_std_11)
-
-target_link_libraries(web_cache pc2l_lib)
-
-find_package(Boost COMPONENTS system thread)
-# link boost, curl, curlpp for web cache example
-target_link_libraries(web_cache ${BOOST_LIBRARIES})
-target_link_libraries(web_cache Boost::thread)
+# find_package(Boost COMPONENTS system thread)
+# # link boost, curl, curlpp for web cache example
+# target_link_libraries(web_cache ${BOOST_LIBRARIES})
+# target_link_libraries(web_cache Boost::thread)
 
 # terrasort
-add_executable(terrasort terrasort.cpp)
+# add_executable(terrasort terrasort.cpp)
+#
+# target_compile_features(terrasort PRIVATE cxx_std_11)
+#
+# target_link_libraries(terrasort pc2l_lib)
+#
+# # terrasort with std::vector
+# add_executable(std_terrasort std_terrasort.cpp)
+#
 
-target_compile_features(terrasort PRIVATE cxx_std_11)
+# minimal example
+add_executable(minimal_example minimal_example.cpp)
 
-target_link_libraries(terrasort pc2l_lib)
+target_compile_features(minimal_example PRIVATE cxx_std_11)
 
-# terrasort with std::vector
-add_executable(std_terrasort std_terrasort.cpp)
-
-
+target_link_libraries(minimal_example pc2l_lib)

--- a/examples/big_vec.cpp
+++ b/examples/big_vec.cpp
@@ -46,6 +46,7 @@ int main(int argc, char *argv[]) {
   // Boilerplate code to get MPI up and running
   auto &pc2l = pc2l::System::get();
   pc2l.initialize(argc, argv);
+  pc2l.setCacheSize(10000);
   pc2l.start();
   ull num = strtoull(argv[1], NULL, 0);
 

--- a/examples/minimal_example.cpp
+++ b/examples/minimal_example.cpp
@@ -1,0 +1,32 @@
+#ifndef MINIMAL_EXAMPLE_CPP
+#define MINIMAL_EXAMPLE_CPP
+
+#include "MPIHelper.h"
+#include <pc2l.h>
+
+int main(int argc, char *argv[]) {
+  // Boilerplate code to get MPI up and running
+  auto &pc2l = pc2l::System::get();
+  pc2l.initialize(argc, argv);
+  // 50 block cache
+  pc2l.setCacheSize(50 * 100 * sizeof(int));
+  pc2l.start();
+
+  if (pc2l::MPI_GET_RANK() == 0) {
+    
+    pc2l::Vector<int, 8 * sizeof(int)> vec(100);
+
+    for (auto i = 0; i < 100; i++) {
+      vec.push_back(i);
+    }
+
+    for (auto i = 0; i < vec.size(); i++) {
+      std::cout << "vec[" << i << "]=" << vec[i] << std::endl;
+    }
+  }
+
+  pc2l.stop();
+  pc2l.finalize();
+}
+
+#endif

--- a/examples/minimal_example.cpp
+++ b/examples/minimal_example.cpp
@@ -13,8 +13,8 @@ int main(int argc, char *argv[]) {
   pc2l.start();
 
   if (pc2l::MPI_GET_RANK() == 0) {
-    
-    pc2l::Vector<int, 8 * sizeof(int)> vec(100);
+
+    pc2l::Vector<int, 8 * sizeof(int)> vec;
 
     for (auto i = 0; i < 100; i++) {
       vec.push_back(i);

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -46,13 +46,10 @@
  */
 
 #include "CacheManager.h"
-#include "MPIHelper.h"
 #include "Message.h"
 #include "System.h"
-#include "Worker.h"
 #include <cmath>
 #include <iterator>
-#include <unordered_map>
 
 // namespace pc2l {
 BEGIN_NAMESPACE(pc2l);

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -373,7 +373,6 @@ public:
     auto [offset, blockTag, inBlockIdx] = indexCalculation(index);
     CacheManager &cm = System::get().cacheManager();
     bool isTail = index == size();
-    std::cout << "isTail " << isTail << " index " << index << std::endl;
 
     if (!isTail) {
       // all other values shifted right one index (size incremented here)

--- a/src/CacheManager.cpp
+++ b/src/CacheManager.cpp
@@ -38,6 +38,8 @@
 //---------------------------------------------------------------------
 #include "CacheManager.h"
 #include "Exception.h"
+#include "MPIHelper.h"
+#include <mpi.h>
 #include <thread>
 
 // namespace pc2l {

--- a/src/LeastRecentlyUsedCacheWorker.cpp
+++ b/src/LeastRecentlyUsedCacheWorker.cpp
@@ -76,7 +76,7 @@ void LeastRecentlyUsedCacheWorker::refer(const MessagePtr &msg) {
           (evicted->blockTag % (System::get().worldSize() - 1)) + 1;
       send(evicted, destRank);
     }
-  } else {
+  } else if (queue.size() > 0) {
     // If the block is present in the cache, we need to update its place in
     // the queue
     queue.erase(entry->second.placeInQueue);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,23 +1,21 @@
 include(GoogleTest)
-enable_testing()
 # function for adding a unit test that utilizes MPI
 function(add_mpi_test name no_mpi_proc)
-    include_directories(${MY_TESTING_INCLUDES})
-    # My test are all called name_test.cpp
-    add_executable(test_${name} test_${name}.cpp)
-    # link with the pc2l library
-    target_link_libraries(test_${name} pc2l_lib)
-    # Make sure to link MPI here too:
-    target_link_libraries(test_${name} ${MPI_CXX_LIBRARY})
-    # and link with testing library, discover tests??
-    target_link_libraries(test_${name} gtest gtest_main)
-    # execute with mpi (e.g. mpirun -n 2, mpiexec, whatever)
-    set(test_parameters "./test_${name}" ${MPIEXEC_NUMPROC_FLAG} ${no_mpi_proc})
-    add_test(NAME test_${name} COMMAND ${MPIEXEC} ${test_parameters})
+	include_directories(${MY_TESTING_INCLUDES})
+	# My test are all called name_test.cpp
+	add_executable(test_${name} test_${name}.cpp)
+	# link with the pc2l library
+	target_link_libraries(test_${name} pc2l_lib)
+	# Make sure to link MPI here too:
+	target_link_libraries(test_${name} ${MPI_CXX_LIBRARY})
+	# and link with testing library, discover tests??
+	target_link_libraries(test_${name} gtest gtest_main)
+	add_test(NAME test_${name}
+		COMMAND mpirun -n "${no_mpi_proc}" "../bin/test_${name}")
 endfunction(add_mpi_test)
 
-add_mpi_test(vector 2)
-add_mpi_test(map 2)
-add_mpi_test(lfu 2)
-add_mpi_test(mru 2)
-add_mpi_test(plru 2)
+add_mpi_test(vector 4)
+add_mpi_test(map 4)
+add_mpi_test(lfu 4)
+add_mpi_test(mru 4)
+add_mpi_test(plru 4)

--- a/test/Environment.h
+++ b/test/Environment.h
@@ -2,6 +2,7 @@
 // Created by jd on 4/5/22.
 //
 
+#include "MPIHelper.h"
 #ifndef PC2L_ENVIRONMENT_H
 #include <gtest/gtest.h>
 #include <mpi.h>
@@ -17,8 +18,6 @@ pc2l::Vector<int, 8 * sizeof(int)> createRangeIntVec(int size) {
 
 class PC2LEnvironment : public ::testing::Environment {
 public:
-  int argc;
-  char **argv;
   // define characteristics of the PC2L instance we will use for testing
   // we use small block sizes here just to test that features are working
   // correctly. Tests for performance are conducted in the examples and/or
@@ -37,11 +36,7 @@ public:
       delete listeners.Release(listeners.default_result_printer());
     }
   }
-  void TearDown() override {
-    auto &pc2l = pc2l::System::get();
-    pc2l.stop();
-    pc2l.finalize();
-  }
+  void TearDown() override {}
 };
 #define PC2L_ENVIRONMENT_H
 

--- a/test/test_lfu.cpp
+++ b/test/test_lfu.cpp
@@ -35,8 +35,7 @@
 //---------------------------------------------------------------------
 
 #include "Environment.h"
-#include <iostream>
-#include <random>
+#include "MPIHelper.h"
 
 class LFUTest : public ::testing::Test {};
 
@@ -46,11 +45,20 @@ int main(int argc, char *argv[]) {
   pc2l.setCacheSize(3 * (sizeof(pc2l::Message) + 8 * sizeof(int)));
   pc2l.initialize(argc, argv);
   pc2l.start(pc2l::System::LeastFrequentlyUsed);
+  auto rank = pc2l::MPI_GET_RANK();
+
   auto env = new PC2LEnvironment();
-  env->argc = argc;
-  env->argv = argv;
   ::testing::AddGlobalTestEnvironment(env);
-  return RUN_ALL_TESTS();
+  auto res = RUN_ALL_TESTS();
+
+  pc2l.stop();
+  pc2l.finalize();
+
+  if (rank == 0) {
+    return res;
+  } else {
+    return 0;
+  }
 }
 
 TEST_F(LFUTest, test_lfu_caching) {

--- a/test/test_mru.cpp
+++ b/test/test_mru.cpp
@@ -35,22 +35,34 @@
 //---------------------------------------------------------------------
 
 #include "Environment.h"
-#include <iostream>
-#include <random>
 
 class MRUTest : public ::testing::Test {};
 
 int main(int argc, char *argv[]) {
+  auto cacheSize = 3 * (sizeof(pc2l::Message) + 8 * sizeof(int));
+
   ::testing::InitGoogleTest(&argc, argv);
   auto &pc2l = pc2l::System::get();
-  pc2l.setCacheSize(3 * (sizeof(pc2l::Message) + 8 * sizeof(int)));
+
   pc2l.initialize(argc, argv);
+  pc2l.setCacheSize(cacheSize);
   pc2l.start(pc2l::System::MostRecentlyUsed);
+
+  auto rank = pc2l::MPI_GET_RANK();
+
   auto env = new PC2LEnvironment();
-  env->argc = argc;
-  env->argv = argv;
   ::testing::AddGlobalTestEnvironment(env);
-  return RUN_ALL_TESTS();
+
+  auto res = RUN_ALL_TESTS();
+
+  pc2l.stop();
+  pc2l.finalize();
+
+  if (rank == 0) {
+    return res;
+  } else {
+    return 0;
+  }
 }
 
 TEST_F(MRUTest, test_mru_caching) {

--- a/test/test_plru.cpp
+++ b/test/test_plru.cpp
@@ -35,22 +35,34 @@
 //---------------------------------------------------------------------
 
 #include "Environment.h"
-#include <iostream>
-#include <random>
 
 class PLRUTest : public ::testing::Test {};
 
 int main(int argc, char *argv[]) {
+  auto cacheSize = 3 * (sizeof(pc2l::Message) + 8 * sizeof(int));
+
   ::testing::InitGoogleTest(&argc, argv);
   auto &pc2l = pc2l::System::get();
-  pc2l.setCacheSize(3 * (sizeof(pc2l::Message) + 8 * sizeof(int)));
+
   pc2l.initialize(argc, argv);
-  pc2l.start(pc2l::System::PseudoLRU);
+  pc2l.setCacheSize(cacheSize);
+  pc2l.start();
+
+  auto rank = pc2l::MPI_GET_RANK();
+
   auto env = new PC2LEnvironment();
-  env->argc = argc;
-  env->argv = argv;
   ::testing::AddGlobalTestEnvironment(env);
-  return RUN_ALL_TESTS();
+
+  auto res = RUN_ALL_TESTS();
+
+  pc2l.stop();
+  pc2l.finalize();
+
+  if (rank == 0) {
+    return res;
+  } else {
+    return 0;
+  }
 }
 
 TEST_F(PLRUTest, test_plru_caching) {


### PR DESCRIPTION
Problem:
I get unexpected behavior when running almost all programs on my computer (e.g. processes exit with nonzero exit codes, sometimes I get a segmentation fault).

Solution:
Add `minimal_example.cpp`, which is the most basic example of PC2L. Keep running that minimal example and try to debug/fix, since a program that does very little should be easier to debug than other examples.